### PR TITLE
Add docs coverage and warning checks to CI and resolve failures for both

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
-        submodules: true
+        submodules: recursive
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
     - name: Set up Python 3.10
       if: github.event_name == 'push' || github.event_name == 'schedule'
@@ -76,7 +76,7 @@ jobs:
       run: |
         cd docs
         bash ./install.sh
-        for w in `find wheelhouse/ -type f -name "*.whl"` ; do poetry install $w ; done
+        poetry run pip install ../.
     - name: Build docs
       if:  (matrix.os == 'ubuntu-latest') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
       timeout-minutes: 20

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,4 +2,19 @@ API documentation
 ~~~~~~~~~~~~~~~~~
 
 .. automodule:: pytket.extensions.projectq
-    :members: tk_to_projectq, tketBackendEngine, tketOptimiser, ProjectQBackend
+.. automodule:: pytket.extensions.projectq._metadata
+.. automodule:: pytket.extensions.projectq.projectq_convert
+
+    .. autofunction:: tk_to_projectq
+    
+    .. autoclass:: tketBackendEngine
+        :members:
+    
+    .. autoclass:: tketOptimiser
+        :members:
+
+.. automodule:: pytket.extensions.projectq.backends
+.. automodule:: pytket.extensions.projectq.backends.projectq_backend
+
+    .. autoclass:: ProjectQBackend
+        :members:

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -13,7 +13,9 @@ EXTENSION_NAME="$(basename "$(dirname `pwd`)")"
 sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
 
 # Build the docs. Ensure we have the correct project title.
-sphinx-build -b html -D html_title="$EXTENSION_NAME" . build 
+sphinx-build -W -b html -D html_title="$EXTENSION_NAME" . build || exit 1
+
+sphinx-build -W -v -b coverage . build/coverage || exit 1
 
 # Remove copied files. This ensures reusability.
 rm -r _static 

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -9,9 +9,6 @@ cp pytket-docs-theming/conf.py .
 # Get the name of the project
 EXTENSION_NAME="$(basename "$(dirname `pwd`)")"
 
-# Correct github link in navbar
-sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
-
 # Build the docs. Ensure we have the correct project title.
 sphinx-build -W -b html -D html_title="$EXTENSION_NAME" . build || exit 1
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ Changelog
 -----------------
 
 * Update pytket minimum version requirement to 2.3.1.
-* Replace internal usage of :py:class:`~pytket.passes.RebaseCustom` with the serializable :py:class:`~pytket.passes.AutoRebase` pass.
+* Replace internal usage of :py:meth:`~pytket.passes.RebaseCustom` with the serializable :py:meth:`~pytket.passes.AutoRebase` pass.
 
 0.37.0 (October 2024)
 ---------------------

--- a/pytket/extensions/projectq/__init__.py
+++ b/pytket/extensions/projectq/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Module for conversion between ProjectQ and tket primitives."""
 
 # _metadata.py is copied to the folder after installation.
 from ._metadata import __extension_name__, __extension_version__

--- a/pytket/extensions/projectq/backends/__init__.py
+++ b/pytket/extensions/projectq/backends/__init__.py
@@ -11,6 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Backend for utilising the ProjectQ simulator directly from pytket"""
 
 from .projectq_backend import ProjectQBackend

--- a/pytket/extensions/projectq/backends/projectq_backend.py
+++ b/pytket/extensions/projectq/backends/projectq_backend.py
@@ -161,7 +161,7 @@ class ProjectQBackend(Backend):
         **kwargs: KwargTypes,
     ) -> list[ResultHandle]:
         """
-        See :py:meth:`pytket.backends.Backend.process_circuits`.
+        See :py:meth:`pytket.backends.backend.Backend.process_circuits`.
         Supported kwargs: `seed`.
         """
         circuits = list(circuits)
@@ -244,14 +244,10 @@ class ProjectQBackend(Backend):
 
         :param state_circuit: Circuit that generates the desired state
             :math:`\\left|\\psi\\right>`.
-        :type state_circuit: Circuit
         :param pauli: Pauli operator
-        :type pauli: QubitPauliString
         :param valid_check: Explicitly check that the circuit satisfies all required
             predicates to run on the backend. Defaults to True
-        :type valid_check: bool, optional
         :return: :math:`\\left<\\psi | P | \\psi \\right>`
-        :rtype: complex
         """
         pauli_tuple = tuple((_default_q_index(q), p.name) for q, p in pauli.map.items())
         return self._expectation_value(
@@ -269,14 +265,10 @@ class ProjectQBackend(Backend):
 
         :param state_circuit: Circuit that generates the desired state
             :math:`\\left|\\psi\\right>`.
-        :type state_circuit: Circuit
         :param operator: Operator :math:`H`. Must be Hermitian.
-        :type operator: QubitPauliOperator
         :param valid_check: Explicitly check that the circuit satisfies all required
             predicates to run on the backend. Defaults to True
-        :type valid_check: bool, optional
         :return: :math:`\\left<\\psi | H | \\psi \\right>`
-        :rtype: complex
         """
         ham = projectq.ops.QubitOperator()
         for term, coeff in operator._dict.items():  # noqa: SLF001

--- a/pytket/extensions/projectq/backends/projectq_backend.py
+++ b/pytket/extensions/projectq/backends/projectq_backend.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Methods to allow tket circuits to be ran on ProjectQ simulator"""
-
 from collections.abc import Sequence
 from logging import warning
 from typing import (

--- a/pytket/extensions/projectq/projectq_convert.py
+++ b/pytket/extensions/projectq/projectq_convert.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Methods to allow conversion between ProjectQ and tket data types"""
-
 from collections.abc import Iterable
 from typing import Any
 

--- a/pytket/extensions/projectq/projectq_convert.py
+++ b/pytket/extensions/projectq/projectq_convert.py
@@ -270,7 +270,9 @@ class tketBackendEngine(BasicEngine):
         :return: The tket Circuit from the engine.
         """
         if self._circuit.n_gates == 0:
-            raise NotImplementedError("Circuit has no gates. Have you flushed your engine?")
+            raise NotImplementedError(
+                "Circuit has no gates. Have you flushed your engine?"
+            )
         return self._circuit
 
     def is_available(self, cmd: ProjectQCommand) -> bool:

--- a/pytket/extensions/projectq/projectq_convert.py
+++ b/pytket/extensions/projectq/projectq_convert.py
@@ -133,11 +133,8 @@ def tk_to_projectq(
     Commands on this Qureg.
 
     :param engine: A ProjectQ MainEngine
-    :type engine: MainEngine
     :param qureg: A ProjectQ Qureg in this MainEngine
-    :type qureg: Qureg
     :param circuit: A tket Circuit
-    :type circuit: Circuit
     """
     if not circuit.is_simple:
         raise Exception("Cannot currently convert non-simple circuits to ProjectQ")
@@ -267,13 +264,15 @@ class tketBackendEngine(BasicEngine):
     @property
     def circuit(self) -> Circuit:
         """
+        Returns the tket Circuit accumulated so far by the engine.
+
         :raises NotImplementedError: If the Circuit has no gates, assumes user forgot to
             flush engines.
 
         :return: The tket Circuit from the engine.
         """
         if self._circuit.n_gates == 0:
-            raise Exception("Circuit has no gates. Have you flushed your engine?")
+            raise NotImplementedError("Circuit has no gates. Have you flushed your engine?")
         return self._circuit
 
     def is_available(self, cmd: ProjectQCommand) -> bool:
@@ -281,7 +280,7 @@ class tketBackendEngine(BasicEngine):
         Ask the next engine whether a command is available, i.e.,
         whether it can be executed by the next engine(s).
 
-        :raises LastEngineException: If is_last_engine is True but is_available is not
+        :raises projectq.cengines.LastEngineException: If is_last_engine is True but is_available is not
             implemented.
 
         :param cmd: Command for which to check availability.


### PR DESCRIPTION
# Description

Adding CI checks for documentation coverage (making sure that every publicly visible method and class - those whose names don't begin with an underscore - is included in the docs) and enforcing sphinx nitpicky to report any formatting failures and broken cross-references.

This PR also resolves existing gaps in coverage and broken formatting. Some of the newly documented content required for docs coverage may have been intended to be internal components required only as part of the conversion or infrastructure code and is not intended for end users; I will need some help spotting any such instances so we can underscore them out to clarify this intention.

# Related issues

This works towards CQCL/tket#1857, following on from CQCL/tket#1910 for the core package and related PRs for other extensions.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
